### PR TITLE
filter out nan points

### DIFF
--- a/include/vlcal/preprocess/dynamic_point_cloud_integrator.hpp
+++ b/include/vlcal/preprocess/dynamic_point_cloud_integrator.hpp
@@ -26,6 +26,7 @@ public:
   ~DynamicPointCloudIntegratorParams();
 
   bool visualize;         ///< If true, show integrated points
+  bool verbose;           ///< If true, print out optimization progress
   int num_threads;        ///< Number of threads
   int k_neighbors;        ///< Number of neighbor points for covariance estimation
   int target_num_points;  ///< Target number of points for downsampling

--- a/src/vlcal/preprocess/dynamic_point_cloud_integrator.cpp
+++ b/src/vlcal/preprocess/dynamic_point_cloud_integrator.cpp
@@ -21,6 +21,7 @@ namespace vlcal {
 
 DynamicPointCloudIntegratorParams::DynamicPointCloudIntegratorParams() {
   visualize = false;
+  verbose = false;
   num_threads = 16;
   k_neighbors = 20;
   target_num_points = 10000;
@@ -92,6 +93,9 @@ void DynamicPointCloudIntegrator::insert_points(const Frame::ConstPtr& raw_point
 
   gtsam::LevenbergMarquardtParams lm_params;
   lm_params.setMaxIterations(10);
+  if (params.verbose) {
+    lm_params.setVerbosityLM("SUMMARY");
+  }
 
   for (int i = 0; i < 3; i++) {
     values = gtsam::LevenbergMarquardtOptimizer(graph, values, lm_params).optimize();


### PR DESCRIPTION
Some LiDAR drivers (e.g., one for VLP16) output point clouds with NaN points that prevent the dynamic points integrator from working properly. This PR adds a filter to remove invalid points to fix issues related to VLP16 https://github.com/koide3/direct_visual_lidar_calibration/issues/13.