### PR TITLE
edit numpy.int to int to adapt newer version of numpy

### DIFF
--- a/scripts/find_matches_superglue.py
+++ b/scripts/find_matches_superglue.py
@@ -142,7 +142,7 @@ def main():
       kp0 = kpts0[i]
       kp1 = kpts1[match]
 
-      color = tuple((numpy.array(cmap(confidence[i])) * 255).astype(numpy.int).tolist())
+      color = tuple((numpy.array(cmap(confidence[i])) * 255).astype(int).tolist())
 
       cv2.line(canvas, (int(kp0[0]), int(kp0[1])), (int(kp1[0]), int(kp1[1])), color)
 


### PR DESCRIPTION
numpy.int (along with other similar types) was deprecated in NumPy 1.20 and subsequently removed in NumPy 1.24. Therefore, using numpy.int in versions after 1.24 will raise an error.
I tested the result, it should be good to edit it.