### PR TITLE
fix missing input for custom intensity_channel field name

### DIFF
--- a/include/vlcal/common/ros_cloud_converter.hpp
+++ b/include/vlcal/common/ros_cloud_converter.hpp
@@ -175,7 +175,7 @@ static RawPoints::Ptr extract_raw_points(const PointCloud2& points_msg, const st
 }
 
 static RawPoints::Ptr extract_raw_points(const PointCloud2ConstPtr& points_msg, const std::string& intensity_channel = "intensity") {
-  return extract_raw_points(*points_msg);
+  return extract_raw_points(*points_msg, intensity_channel);
 }
 
 }  // namespace vlcal


### PR DESCRIPTION
fix missing input for customize intensity_channel field name in ros_cloud_converter.