### PR TITLE
Add Boost date_time component to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(PCL REQUIRED)
 find_package(Ceres REQUIRED)
 find_package(GTSAM REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem program_options)
+find_package(Boost REQUIRED COMPONENTS filesystem program_options date_time)
 find_package(Iridescence REQUIRED)
 
 set(OLD_DISTRO "humble;galactic;foxy")


### PR DESCRIPTION
Meet error when doing the compile
```
CMake Error at /opt/ros/humble/share/ament_cmake_auto/cmake/ament_auto_add_executable.cmake:66 (add_executable):
  Target "preprocess" links to target "Boost::date_time" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:103 (ament_auto_add_executable)


CMake Error at /opt/ros/humble/share/ament_cmake_auto/cmake/ament_auto_add_executable.cmake:66 (add_executable):
  Target "preprocess" links to target "Boost::date_time" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:103 (ament_auto_add_executable)


CMake Error at /opt/ros/humble/share/ament_cmake_auto/cmake/ament_auto_add_executable.cmake:66 (add_executable):
  Target "preprocess" links to target "Boost::date_time" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:103 (ament_auto_add_executable)
```

gcc 9.5.0, Ubuntu 22.04.5, boost 1.74.0.3, ros2 humble