### PR TITLE
Support GTSAM 4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 find_package(PCL REQUIRED)
 find_package(Ceres REQUIRED)
-find_package(GTSAM REQUIRED)
+find_package(GTSAM CONFIG REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem program_options date_time)
 find_package(Iridescence REQUIRED)
@@ -69,7 +69,6 @@ target_include_directories(direct_visual_lidar_calibration PUBLIC
   thirdparty/Sophus
   ${Boost_INCLUDE_DIRS}
   ${CERES_INCLUDE_DIRS}
-  ${GTSAM_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )
@@ -78,7 +77,7 @@ target_link_libraries(direct_visual_lidar_calibration
   ${Boost_LIBRARIES}
   ${PCL_LIBRARIES}
   ${CERES_LIBRARIES}
-  ${GTSAM_LIBRARIES}
+  gtsam
   ${OpenCV_LIBRARIES}
   Iridescence::Iridescence
 )

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ sudo apt install libomp-dev libboost-all-dev libglm-dev libglfw3-dev libpng-dev 
 
 # Install GTSAM
 git clone https://github.com/borglab/gtsam
-cd gtsam && git checkout 4.2a9
+cd gtsam && git checkout 4.3a1
 mkdir build && cd build
 # For Ubuntu 22.04, add -DGTSAM_USE_SYSTEM_EIGEN=ON
 cmake .. -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF \

--- a/include/vlcal/common/integrated_ct_gicp_factor.hpp
+++ b/include/vlcal/common/integrated_ct_gicp_factor.hpp
@@ -13,7 +13,7 @@ template <typename TargetFrame = Frame, typename SourceFrame = Frame>
 class IntegratedCT_GICPFactor_ : public IntegratedCT_ICPFactor_<TargetFrame, SourceFrame> {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  using shared_ptr = boost::shared_ptr<IntegratedCT_GICPFactor_<TargetFrame, SourceFrame>>;
+  using shared_ptr = std::shared_ptr<IntegratedCT_GICPFactor_<TargetFrame, SourceFrame>>;
 
   /**
    * @brief Constructor
@@ -46,7 +46,7 @@ public:
   virtual ~IntegratedCT_GICPFactor_() override;
 
   virtual double error(const gtsam::Values& values) const override;
-  virtual boost::shared_ptr<gtsam::GaussianFactor> linearize(const gtsam::Values& values) const override;
+  virtual std::shared_ptr<gtsam::GaussianFactor> linearize(const gtsam::Values& values) const override;
 
 protected:
   virtual void update_correspondences() const override;

--- a/include/vlcal/common/integrated_ct_gicp_factor_impl.hpp
+++ b/include/vlcal/common/integrated_ct_gicp_factor_impl.hpp
@@ -67,7 +67,7 @@ double IntegratedCT_GICPFactor_<TargetFrame, SourceFrame>::error(const gtsam::Va
 }
 
 template <typename TargetFrame, typename SourceFrame>
-boost::shared_ptr<gtsam::GaussianFactor> IntegratedCT_GICPFactor_<TargetFrame, SourceFrame>::linearize(const gtsam::Values& values) const {
+std::shared_ptr<gtsam::GaussianFactor> IntegratedCT_GICPFactor_<TargetFrame, SourceFrame>::linearize(const gtsam::Values& values) const {
   this->update_poses(values);
   this->update_correspondences();
 

--- a/include/vlcal/common/integrated_ct_icp_factor.hpp
+++ b/include/vlcal/common/integrated_ct_icp_factor.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
 
@@ -20,7 +22,7 @@ template <typename TargetFrame = Frame, typename SourceFrame = Frame>
 class IntegratedCT_ICPFactor_ : public gtsam::NonlinearFactor {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  using shared_ptr = boost::shared_ptr<IntegratedCT_ICPFactor_<TargetFrame, SourceFrame>>;
+  using shared_ptr = std::shared_ptr<IntegratedCT_ICPFactor_<TargetFrame, SourceFrame>>;
 
   /**
    * @brief Constructor
@@ -54,7 +56,7 @@ public:
 
   virtual size_t dim() const override { return 6; }
   virtual double error(const gtsam::Values& values) const override;
-  virtual boost::shared_ptr<gtsam::GaussianFactor> linearize(const gtsam::Values& values) const override;
+  virtual std::shared_ptr<gtsam::GaussianFactor> linearize(const gtsam::Values& values) const override;
 
   void set_num_threads(int n) { num_threads = n; }
   void set_max_corresponding_distance(double dist) { max_correspondence_distance_sq = dist * dist; }

--- a/include/vlcal/common/integrated_ct_icp_factor_impl.hpp
+++ b/include/vlcal/common/integrated_ct_icp_factor_impl.hpp
@@ -94,7 +94,7 @@ double IntegratedCT_ICPFactor_<TargetFrame, SourceFrame>::error(const gtsam::Val
 }
 
 template <typename TargetFrame, typename SourceFrame>
-boost::shared_ptr<gtsam::GaussianFactor> IntegratedCT_ICPFactor_<TargetFrame, SourceFrame>::linearize(const gtsam::Values& values) const {
+std::shared_ptr<gtsam::GaussianFactor> IntegratedCT_ICPFactor_<TargetFrame, SourceFrame>::linearize(const gtsam::Values& values) const {
   if (!frame::has_normals(*target)) {
     std::cerr << "error: target cloud doesn't have normals!!" << std::endl;
     abort();

--- a/src/vlcal/preprocess/dynamic_point_cloud_integrator.cpp
+++ b/src/vlcal/preprocess/dynamic_point_cloud_integrator.cpp
@@ -84,7 +84,7 @@ void DynamicPointCloudIntegrator::insert_points(const Frame::ConstPtr& raw_point
   values.insert(1, pred_T_odom_lidar_end);
 
   gtsam::NonlinearFactorGraph graph;
-  auto factor = boost::make_shared<IntegratedCT_GICPFactor_<iVox, Frame>>(0, 1, target_ivox, points, target_ivox);
+  auto factor = std::make_shared<IntegratedCT_GICPFactor_<iVox, Frame>>(0, 1, target_ivox, points, target_ivox);
   factor->set_num_threads(params.num_threads);
   graph.add(factor);
 


### PR DESCRIPTION
操作ミスにより、個人のfork内で作業するつもりだった変更について、誤って本リポジトリ宛てにPRを作成してしまいました。
本PRを提出する意図はなく、動作確認も未完了です。

お忙しいところ、不要な通知をお送りしてしまい大変申し訳ございません。
本PRはクローズいたします。

## What changed

- Discover GTSAM through its official CMake package config and link the imported `gtsam` target.
- Migrate the custom ICP/GICP factors from `boost::shared_ptr` to `std::shared_ptr` for GTSAM 4.3.
- Construct the dynamic integration factor with `std::make_shared`.
- Update the installation guide to select GTSAM 4.3a1.

## Why

GTSAM 4.3 changed nonlinear and Gaussian factor ownership from Boost shared pointers to standard-library shared pointers. The previous custom factor overrides therefore had incompatible return types, and the generated factor could not be inserted into `NonlinearFactorGraph`.

## Validation

- Built on ROS 2 Jazzy with GTSAM 4.3.0 using:
  `colcon build --packages-select direct_visual_lidar_calibration --cmake-clean-cache`
- Confirmed the resulting library links to `/usr/local/lib/libgtsam.so.4.3a1`.
- Confirmed `--help` exits successfully for `preprocess`, `preprocess_map`, `initial_guess_manual`, `initial_guess_auto`, `calibrate`, and `viewer`.
- `git diff --check` passes.
